### PR TITLE
[RFC] Stage1 - Vcpu

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {  
-  "coverage_score": 88.8,
+  "coverage_score": 88.9,
   "exclude_path": "msr_index.rs,mpspec.rs,tests/",
   "crate_features": ""
 }

--- a/resources/kernel/make_busybox.sh
+++ b/resources/kernel/make_busybox.sh
@@ -185,15 +185,7 @@ else
     VMLINUX="vmlinux-hello-busybox"
 fi
 
-# Step 2.a): we have it cached locally.
-if [ -f "$WORKDIR/$KERNEL/$VMLINUX" ]; then
-    echo "Found $VMLINUX in $WORKDIR/$KERNEL."
-    cp "$WORKDIR/$KERNEL/$VMLINUX" "$TEST_RESOURCE_DIR"
-    echo "Copied to $TEST_RESOURCE_DIR."
-    exit 0
-fi
-
-# Step 2.b): start from scratch.
+# Step 2: start from scratch.
 mkdir -p "$WORKDIR" && cd "$WORKDIR"
 
 # Step 3: acquire kernel sources & config.

--- a/resources/kernel/make_busybox.sh
+++ b/resources/kernel/make_busybox.sh
@@ -115,7 +115,7 @@ mount -t sysfs none /sys
 EOF
 
     if [ -z "$halt" ]; then
-        echo "exec /bin/sh" >>init
+        echo "setsid /bin/sh -c 'exec /bin/sh </dev/ttyS0 >/dev/ttyS0 2>&1'" >>init
     else
         echo "exec /sbin/halt" >>init
     fi
@@ -139,6 +139,7 @@ make_initramfs() {
     echo "Creating device nodes..."
     rm -f sda && mknod sda b 8 0
     rm -f console && mknod console c 5 1
+    rm -f ttyS0 && mknod ttyS0 c 4 64
 
     make_init "$halt"
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -111,7 +111,6 @@ pub struct VMM {
     // perspective, and a dyn MutEventSubscriber from EventManager's) is managed by the 2 entities,
     // and isn't Copy-able; so once one of them gets ownership, the other one can't anymore.
     event_mgr: EventManager<Arc<Mutex<dyn MutEventSubscriber>>>,
-    vcpus: Vec<Vcpu>,
 }
 
 impl VMM {
@@ -134,7 +133,6 @@ impl VMM {
             guest_memory: GuestMemoryMmap::default(),
             device_mgr: Some(IoManager::new()),
             event_mgr: EventManager::new().map_err(Error::EventManager)?,
-            vcpus: vec![],
         };
 
         vmm.check_kvm_capabilities()?;

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -11,16 +11,12 @@ use std::ffi::CString;
 use std::fs::File;
 use std::io::{self, stdin, stdout};
 use std::sync::{Arc, Mutex};
-use std::thread;
 
 use event_manager::{EventManager, MutEventSubscriber, SubscriberOps};
-use kvm_bindings::{
-    kvm_pit_config, kvm_userspace_memory_region, CpuId, KVM_API_VERSION, KVM_MAX_CPUID_ENTRIES,
-    KVM_PIT_SPEAKER_DUMMY,
-};
+use kvm_bindings::{kvm_userspace_memory_region, CpuId, KVM_API_VERSION, KVM_MAX_CPUID_ENTRIES};
 use kvm_ioctls::{
     Cap::{self, Ioeventfd, Irqchip, Irqfd, UserMemory},
-    Kvm, VmFd,
+    Kvm,
 };
 use linux_loader::bootparam::boot_params;
 use linux_loader::cmdline::{self, Cmdline};
@@ -44,7 +40,9 @@ mod devices;
 use devices::SerialWrapper;
 
 mod vcpu;
+mod vm;
 use vcpu::{cpuid, mpspec, mptable, Vcpu};
+use vm::KvmVm;
 
 /// First address past 32 bits.
 const FIRST_ADDR_PAST_32BITS: u64 = 1 << 32;
@@ -93,6 +91,14 @@ pub enum Error {
     Memory(MemoryError),
     /// vCPU errors.
     Vcpu(vcpu::Error),
+    /// VM errors.
+    Vm(vm::Error),
+}
+
+impl std::convert::From<vm::Error> for Error {
+    fn from(vm_error: vm::Error) -> Self {
+        Self::Vm(vm_error)
+    }
 }
 
 /// Dedicated [`Result`](https://doc.rust-lang.org/std/result/) type.
@@ -100,8 +106,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// A live VMM.
 pub struct VMM {
-    vm_fd: VmFd,
     kvm: Kvm,
+    vm: KvmVm,
     guest_memory: GuestMemoryMmap,
     // An Option, of all things, because it needs to be mutable while adding devices (so it can't
     // be in an Arc), then it needs to be packed in an Arc to share it across vCPUs. An Option
@@ -125,10 +131,10 @@ impl VMM {
         }
 
         // Create fd for interacting with kvm-vm specific functions.
-        let vm_fd = kvm.create_vm().map_err(Error::KvmIoctl)?;
+        let vm = KvmVm::new(&kvm)?;
 
         let vmm = VMM {
-            vm_fd,
+            vm,
             kvm,
             guest_memory: GuestMemoryMmap::default(),
             device_mgr: Some(IoManager::new()),
@@ -171,26 +177,23 @@ impl VMM {
         }
 
         // Register guest memory regions with KVM.
-        guest_memory
-            .with_regions(|index, region| {
-                let memory_region = kvm_userspace_memory_region {
-                    slot: index as u32,
-                    guest_phys_addr: region.start_addr().raw_value(),
-                    memory_size: region.len() as u64,
-                    // It's safe to unwrap because the guest address is valid.
-                    userspace_addr: guest_memory.get_host_address(region.start_addr()).unwrap()
-                        as u64,
-                    flags: 0,
-                };
+        guest_memory.with_regions(|index, region| {
+            let memory_region = kvm_userspace_memory_region {
+                slot: index as u32,
+                guest_phys_addr: region.start_addr().raw_value(),
+                memory_size: region.len() as u64,
+                // It's safe to unwrap because the guest address is valid.
+                userspace_addr: guest_memory.get_host_address(region.start_addr()).unwrap() as u64,
+                flags: 0,
+            };
 
-                // Safe because:
-                // * userspace_addr is a valid address for a memory region, obtained by calling
-                //   get_host_address() on a valid region's start address;
-                // * the memory regions do not overlap - there's either a single region spanning
-                //   the whole guest memory, or 2 regions with the MMIO gap in between.
-                unsafe { self.vm_fd.set_user_memory_region(memory_region) }
-            })
-            .map_err(Error::KvmIoctl)?;
+            // Safe because:
+            // * userspace_addr is a valid address for a memory region, obtained by calling
+            //   get_host_address() on a valid region's start address;
+            // * the memory regions do not overlap - there's either a single region spanning
+            //   the whole guest memory, or 2 regions with the MMIO gap in between.
+            unsafe { self.vm.set_user_memory_region(memory_region) }
+        })?;
 
         self.guest_memory = guest_memory;
 
@@ -258,22 +261,7 @@ impl VMM {
     /// * `x86_64`: serial console
     /// * `aarch64`: N/A
     pub fn configure_pio_devices(&mut self) -> Result<()> {
-        // First, create the irqchip.
-        // On `x86_64`, this _must_ be created _before_ the vCPUs.
-        // It sets up the virtual IOAPIC, virtual PIC, and sets up the future vCPUs for local APIC.
-        // When in doubt, look in the kernel for `KVM_CREATE_IRQCHIP`.
-        // https://elixir.bootlin.com/linux/latest/source/arch/x86/kvm/x86.c
-        self.vm_fd.create_irq_chip().map_err(Error::KvmIoctl)?;
-
-        // Set up the speaker PIT, because some kernels are musical and access the speaker port
-        // during boot. Without this, KVM would continuously exit to userspace.
-        // TODO: does this *need* the irqchip in place?
-        let mut pit_config = kvm_pit_config::default();
-        pit_config.flags = KVM_PIT_SPEAKER_DUMMY;
-        self.vm_fd
-            .create_pit2(pit_config)
-            .map_err(Error::KvmIoctl)?;
-
+        self.vm.setup_irq_controller()?;
         // Create the serial console.
         let interrupt_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(Error::IO)?;
         let serial = Arc::new(Mutex::new(SerialWrapper(Serial::new(
@@ -283,9 +271,7 @@ impl VMM {
 
         // Register its interrupt fd with KVM. IRQ line 4 is typically used for serial port 1.
         // See more IRQ assignments & info: https://tldp.org/HOWTO/Serial-HOWTO-8.html
-        self.vm_fd
-            .register_irqfd(&interrupt_evt, 4)
-            .map_err(Error::KvmIoctl)?;
+        self.vm.register_irqfd(&interrupt_evt, 4)?;
 
         // Put it on the bus.
         // Safe to use expect() because the device manager is instantiated in new(), there's no
@@ -322,32 +308,30 @@ impl VMM {
         mptable::setup_mptable(&self.guest_memory, vcpu_cfg.num_vcpus)
             .map_err(|e| Error::Vcpu(vcpu::Error::Mptable(e)))?;
 
-        let base_cpuid = self
-            .kvm
-            .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
-            .map_err(Error::KvmIoctl)?;
-
         // Safe to use expect() because the device manager is instantiated in new(), there's no
         // default implementation, and the field is private inside the VMM struct.
         let shared_device_mgr = Arc::new(self.device_mgr.take().expect("Missing device manager"));
 
         for index in 0..vcpu_cfg.num_vcpus {
-            let vcpu =
-                Vcpu::new(&self.vm_fd, index, shared_device_mgr.clone()).map_err(Error::Vcpu)?;
-
             // Set CPUID.
+            self.vm.create_vcpu(index, shared_device_mgr.clone())?;
+        }
+        // Set CPUID.
+        let base_cpuid = self
+            .kvm
+            .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
+            .map_err(Error::KvmIoctl)?;
+        for vcpu in self.vm.vcpus.iter() {
             let mut vcpu_cpuid = base_cpuid.clone();
             cpuid::filter_cpuid(
                 &self.kvm,
-                index as usize,
+                vcpu.id() as usize,
                 vcpu_cfg.num_vcpus as usize,
                 &mut vcpu_cpuid,
             );
 
             self.configure_vcpu(&vcpu, &vcpu_cpuid, kernel_load)
                 .map_err(Error::Vcpu)?;
-
-            self.vcpus.push(vcpu);
         }
 
         Ok(())
@@ -359,11 +343,9 @@ impl VMM {
             eprintln!("Failed to set raw mode on terminal. Stdin will echo.");
         }
 
-        for mut vcpu in self.vcpus.drain(..) {
-            let _ = thread::Builder::new().spawn(move || loop {
-                vcpu.run();
-            });
-        }
+        // TODO: should we handle this in another way rather than a panic?
+        self.vm.run().expect("Cannot start vcpus.");
+
         loop {
             match self.event_mgr.run() {
                 Ok(_) => (),

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -30,9 +30,7 @@ use linux_loader::configurator::{
 use linux_loader::loader::{self, elf::Elf, load_cmdline, KernelLoader, KernelLoaderResult};
 use vm_device::device_manager::IoManager;
 use vm_device::resources::Resource;
-use vm_memory::{
-    Address, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,
-};
+use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 use vm_superio::Serial;
 use vmm_sys_util::{eventfd::EventFd, terminal::Terminal};
 
@@ -62,8 +60,6 @@ const CMDLINE_START: u64 = 0x0002_0000;
 /// VMM memory related errors.
 #[derive(Debug)]
 pub enum MemoryError {
-    /// Failure during guest memory operation.
-    GuestMemory(GuestMemoryError),
     /// Not enough memory slots.
     NotEnoughMemorySlots,
     /// Failed to configure guest memory.

--- a/src/vmm/src/vcpu/mod.rs
+++ b/src/vmm/src/vcpu/mod.rs
@@ -57,6 +57,7 @@ pub type Result<T> = result::Result<T, Error>;
 /// This struct is a temporary (and quite terrible) placeholder until the
 /// [`vmm-vcpu`](https://github.com/rust-vmm/vmm-vcpu) crate is stabilized.
 pub(crate) struct Vcpu {
+    id: u8,
     /// KVM file descriptor for a vCPU.
     pub vcpu_fd: VcpuFd,
     /// Device manager for bus accesses.
@@ -67,9 +68,14 @@ impl Vcpu {
     /// Create a new vCPU.
     pub fn new(vm_fd: &VmFd, index: u8, device_mgr: Arc<IoManager>) -> Result<Self> {
         Ok(Vcpu {
+            id: index,
             vcpu_fd: vm_fd.create_vcpu(index).map_err(Error::KvmIoctl)?,
             device_mgr,
         })
+    }
+
+    pub fn id(&self) -> u8 {
+        self.id
     }
 
     /// Set CPUID.

--- a/src/vmm/src/vcpu/mod.rs
+++ b/src/vmm/src/vcpu/mod.rs
@@ -52,39 +52,49 @@ pub enum Error {
 /// Dedicated Result type.
 pub type Result<T> = result::Result<T, Error>;
 
+pub(crate) struct VcpuState {
+    pub id: u8,
+    pub cpuid: CpuId,
+    pub kernel_load_addr: GuestAddress,
+}
+
 /// Struct for interacting with vCPUs.
 ///
 /// This struct is a temporary (and quite terrible) placeholder until the
 /// [`vmm-vcpu`](https://github.com/rust-vmm/vmm-vcpu) crate is stabilized.
 pub(crate) struct Vcpu {
-    id: u8,
     /// KVM file descriptor for a vCPU.
     pub vcpu_fd: VcpuFd,
     /// Device manager for bus accesses.
     pub device_mgr: Arc<IoManager>,
+    state: VcpuState,
 }
 
 impl Vcpu {
     /// Create a new vCPU.
-    pub fn new(vm_fd: &VmFd, index: u8, device_mgr: Arc<IoManager>) -> Result<Self> {
-        Ok(Vcpu {
-            id: index,
-            vcpu_fd: vm_fd.create_vcpu(index).map_err(Error::KvmIoctl)?,
+    pub fn new(vm_fd: &VmFd, device_mgr: Arc<IoManager>, state: VcpuState, memory: &GuestMemoryMmap) -> Result<Self> {
+        let vcpu = Vcpu {
+            vcpu_fd: vm_fd.create_vcpu(state.id).map_err(Error::KvmIoctl)?,
             device_mgr,
-        })
-    }
+            state,
+        };
 
-    pub fn id(&self) -> u8 {
-        self.id
+        vcpu.configure_cpuid(&vcpu.state.cpuid)?;
+        vcpu.configure_msrs()?;
+        vcpu.configure_regs(vcpu.state.kernel_load_addr)?;
+        vcpu.configure_sregs(memory)?;
+        vcpu.configure_lapic()?;
+        vcpu.configure_fpu()?;
+        Ok(vcpu)
     }
 
     /// Set CPUID.
-    pub fn configure_cpuid(&self, cpuid: &CpuId) -> Result<()> {
+    fn configure_cpuid(&self, cpuid: &CpuId) -> Result<()> {
         self.vcpu_fd.set_cpuid2(cpuid).map_err(Error::KvmIoctl)
     }
 
     /// Configure MSRs.
-    pub fn configure_msrs(&self) -> Result<()> {
+    fn configure_msrs(&self) -> Result<()> {
         let entry_vec = msrs::create_boot_msr_entries();
         let msrs = Msrs::from_entries(&entry_vec);
         self.vcpu_fd
@@ -100,7 +110,7 @@ impl Vcpu {
     }
 
     /// Configure regs.
-    pub fn configure_regs(&self, kernel_load: GuestAddress) -> Result<()> {
+    fn configure_regs(&self, kernel_load: GuestAddress) -> Result<()> {
         let regs = kvm_regs {
             rflags: 0x0000_0000_0000_0002u64,
             rip: kernel_load.raw_value(),
@@ -118,7 +128,7 @@ impl Vcpu {
     }
 
     /// Configure sregs.
-    pub fn configure_sregs(&self, guest_memory: &GuestMemoryMmap) -> Result<()> {
+    fn configure_sregs(&self, guest_memory: &GuestMemoryMmap) -> Result<()> {
         let mut sregs = self.vcpu_fd.get_sregs().map_err(Error::KvmIoctl)?;
 
         // Global descriptor tables.
@@ -186,7 +196,7 @@ impl Vcpu {
     }
 
     /// Configure FPU.
-    pub fn configure_fpu(&self) -> Result<()> {
+    fn configure_fpu(&self) -> Result<()> {
         let fpu = kvm_fpu {
             fcw: 0x37f,
             mxcsr: 0x1f80,
@@ -196,7 +206,7 @@ impl Vcpu {
     }
 
     /// Configures LAPICs. LAPIC0 is set for external interrupts, LAPIC1 is set for NMI.
-    pub fn configure_lapic(&self) -> Result<()> {
+    fn configure_lapic(&self) -> Result<()> {
         let mut klapic = self.vcpu_fd.get_lapic().map_err(Error::KvmIoctl)?;
 
         let lvt_lint0 = get_klapic_reg(&klapic, APIC_LVT0);

--- a/src/vmm/src/vm.rs
+++ b/src/vmm/src/vm.rs
@@ -1,0 +1,127 @@
+use crate::vcpu::{self, Vcpu};
+use kvm_bindings::{kvm_pit_config, kvm_userspace_memory_region, KVM_PIT_SPEAKER_DUMMY};
+use kvm_ioctls::{Kvm, VmFd};
+use std::sync::Arc;
+use std::thread;
+use vm_device::device_manager::IoManager;
+use vmm_sys_util::eventfd::EventFd;
+
+/// A KVM specific implementation of a Virtual Machine.
+///
+/// Provides abstractions for working with a VM. Once a generic Vm trait will be available,
+/// this type will become on of the concrete implementations.
+pub struct KvmVm {
+    fd: VmFd,
+    pub(crate) vcpus: Vec<Vcpu>,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to create a VM.
+    CreateVm(kvm_ioctls::Error),
+    /// Failed to setup the user memory regions.
+    SetupMemoryRegion(kvm_ioctls::Error),
+    /// Failed to setup the interrupt controller.
+    SetupInterruptController(kvm_ioctls::Error),
+    /// Failed to create the vcpu.
+    CreateVcpu(vcpu::Error),
+    /// Failed to register IRQ event.
+    RegisterIrqEvent(kvm_ioctls::Error),
+}
+
+// TODO: Implement std::error::Error for Error.
+
+/// Dedicated [`Result`](https://doc.rust-lang.org/std/result/) type.
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl KvmVm {
+    /// Create a new `KvmVm`.
+    pub fn new(kvm: &Kvm) -> Result<Self> {
+        let fd = kvm.create_vm().map_err(Error::CreateVm)?;
+        Ok(KvmVm {
+            fd,
+            vcpus: Vec::new(),
+        })
+    }
+    /// Set the user memory region.
+    // This function can be easily be part of the hypervisor agnostic interface once we
+    // redefine `memory_region` such that it does not use KVM primitives.
+    pub unsafe fn set_user_memory_region(
+        &self,
+        memory_region: kvm_userspace_memory_region,
+    ) -> Result<()> {
+        self.fd
+            .set_user_memory_region(memory_region)
+            .map_err(Error::SetupMemoryRegion)
+    }
+
+    /// Configures the in kernel interrupt controller.
+    // This function should be reuse to configure the aarch64 interrupt controller (GIC).
+    pub fn setup_irq_controller(&self) -> Result<()> {
+        // First, create the irqchip.
+        // On `x86_64`, this _must_ be created _before_ the vCPUs.
+        // It sets up the virtual IOAPIC, virtual PIC, and sets up the future vCPUs for local APIC.
+        // When in doubt, look in the kernel for `KVM_CREATE_IRQCHIP`.
+        // https://elixir.bootlin.com/linux/latest/source/arch/x86/kvm/x86.c
+        self.fd
+            .create_irq_chip()
+            .map_err(Error::SetupInterruptController)?;
+
+        // The PIT is used during boot to configure the frequency.
+        // The output from PIT channel 0 is connected to the PIC chip, so that it
+        // generates an "IRQ 0" (system timer).
+        // https://wiki.osdev.org/Programmable_Interval_Timer
+        let mut pit_config = kvm_pit_config::default();
+        // Set up the speaker PIT, because some kernels are musical and access the speaker port
+        // during boot. Without this, KVM would continuously exit to userspace.
+        pit_config.flags = KVM_PIT_SPEAKER_DUMMY;
+        self.fd
+            .create_pit2(pit_config)
+            .map_err(Error::SetupInterruptController)
+    }
+
+    /// Create a Vcpu based on the passed configuration.
+    // TODO: Should this return the Vcpu or just directly insert it in the vcpu_handles?
+    // TODO: This should not be pub (crate). Make it pub after removing `serial_console` param.
+    // Right now this is complicated to abstract because the Vcpu holds a reference to
+    // the Serial Console. Waiting on the creation of a Bus before defining the implementation.
+    pub(crate) fn create_vcpu(&mut self, index: u8, bus: Arc<IoManager>) -> Result<()> {
+        let vcpu = Vcpu::new(&self.fd, index, bus).map_err(Error::CreateVcpu)?;
+        self.vcpus.push(vcpu);
+        Ok(())
+    }
+
+    /// Let KVM know that instead of triggering an actual interrupt for `irq_number`, we will
+    /// just write on the specified `event`.
+    // TODO: Add a check for `irq_number`. Since we are only supporting the in-kernel IRQ chip
+    // right now, we shouldn't allow irq_number > 15 (I think?).
+    pub fn register_irqfd(&self, event: &EventFd, irq_number: u32) -> Result<()> {
+        self.fd
+            .register_irqfd(&event, irq_number)
+            .map_err(Error::RegisterIrqEvent)
+    }
+
+    pub fn run(&mut self) {
+        for mut vcpu in self.vcpus.drain(..) {
+            let _ = thread::Builder::new().spawn(move || loop {
+                vcpu.run();
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_invalid_irqfd() {
+        let kvm = Kvm::new().unwrap();
+        let vm = KvmVm::new(&kvm).unwrap();
+
+        let eventfd = EventFd::new(0).unwrap();
+        vm.setup_irq_controller().unwrap();
+        // TODO: This should fail.
+        vm.register_irqfd(&eventfd, 4294967295).unwrap();
+    }
+}


### PR DESCRIPTION
Not yet done, only separated the `Vm` and removed `Vcpu` from the central `Vmm` object.
Still todo:
- figure out how to move the configure vcpu out of `Vmm` and into `Vm`.